### PR TITLE
Update to use htsjdk 2.4.1

### DIFF
--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -27,15 +27,15 @@ dist.jar=${dist.dir}/RAPTR-SV.jar
 dist.javadoc.dir=${dist.dir}/javadoc
 endorsed.classpath=
 excludes=
-file.reference.sam-1.113.jar=../../../Users/bickhart/Downloads/sam-1.113.jar
+htsjdk.jar=/home/user/htsjdk/build/libs/htsjdk-2.4.1-SNAPSHOT.jar
 includes=**
 jar.archive.disabled=${jnlp.enabled}
 jar.compress=false
 jar.index=${jnlp.enabled}
 javac.classpath=\
+    ${htsjdk.jar}:\
     ${reference.ObjectUtils.jar}:\
     ${reference.BedUtils.jar}:\
-    ${file.reference.sam-1.113.jar}:\
     ${reference.FileTools.jar}
 # Space-separated list of extra javac options
 javac.compilerargs=

--- a/src/dataStructs/SamOutputHandle.java
+++ b/src/dataStructs/SamOutputHandle.java
@@ -16,7 +16,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import net.sf.samtools.SAMRecord;
+import htsjdk.samtools.SAMRecord;
 
 /**
  *

--- a/src/dataStructs/SamRecordMatcher.java
+++ b/src/dataStructs/SamRecordMatcher.java
@@ -29,13 +29,13 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import net.sf.samtools.Cigar;
-import net.sf.samtools.CigarOperator;
-import net.sf.samtools.SAMFormatException;
-import net.sf.samtools.SAMReadGroupRecord;
-import net.sf.samtools.SAMRecord;
-import net.sf.samtools.SAMRecordIterator;
-import net.sf.samtools.TextCigarCodec;
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.CigarOperator;
+import htsjdk.samtools.SAMFormatException;
+import htsjdk.samtools.SAMReadGroupRecord;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMRecordIterator;
+import htsjdk.samtools.TextCigarCodec;
 import stats.ReadNameUtility;
 import workers.TextFileQuickSort;
 
@@ -582,7 +582,7 @@ public class SamRecordMatcher extends TempDataClass {
         }
         Cigar c = null;
         try{
-            c = TextCigarCodec.getSingleton().decode(segs[7]);
+            c = TextCigarCodec.decode(segs[7]);
         }catch(Exception ex){
             log.log(Level.SEVERE, "[SAMMATCH] Issplit generated error with faulty alignment: " + StrUtils.StrArray.Join(segs, "\t"), ex);
         }
@@ -593,7 +593,7 @@ public class SamRecordMatcher extends TempDataClass {
     
     private boolean isAnchor(String[] segs){
         int fflags = Integer.parseInt(segs[3]);
-        Cigar c = TextCigarCodec.getSingleton().decode(segs[7]);
+        Cigar c = TextCigarCodec.decode(segs[7]);
         return (fflags & 0x4) != 0x4 && (fflags & 0x8) == 0x8 && !segs[4].equals("*") && !isOverSoftClipThreshold(c, segs[11].length());
     }
     

--- a/src/dataStructs/SplitOutputHandle.java
+++ b/src/dataStructs/SplitOutputHandle.java
@@ -15,15 +15,15 @@ import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import net.sf.samtools.CigarElement;
-import net.sf.samtools.CigarOperator;
-import net.sf.samtools.DefaultSAMRecordFactory;
-import net.sf.samtools.SAMFileHeader;
-import net.sf.samtools.SAMFileWriter;
-import net.sf.samtools.SAMFileWriterFactory;
-import net.sf.samtools.SAMRecord;
-import net.sf.samtools.SAMRecordFactory;
-import net.sf.samtools.TextCigarCodec;
+import htsjdk.samtools.CigarElement;
+import htsjdk.samtools.CigarOperator;
+import htsjdk.samtools.DefaultSAMRecordFactory;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMRecordFactory;
+import htsjdk.samtools.TextCigarCodec;
 
 /**
  *
@@ -38,7 +38,6 @@ public class SplitOutputHandle {
     private SAMFileWriter anchorOut;
     private final SAMFileHeader header;
     private boolean fileopen = false;
-    private final TextCigarCodec cd = TextCigarCodec.getSingleton();
     private final int splitreadlen;
     private AtomicInteger discardCounter = new AtomicInteger(0);
     private AtomicInteger errorCounter = new AtomicInteger(0);
@@ -186,7 +185,7 @@ public class SplitOutputHandle {
     
     private int firstSplitSeg(String cigar, int readlen){
         int start = 0;
-        for(CigarElement e : cd.decode(cigar).getCigarElements()){
+        for(CigarElement e : TextCigarCodec.decode(cigar).getCigarElements()){
             if(e.getOperator().equals(CigarOperator.S) && e.getLength() > readlen * 0.20){
                 if (start == 0)
                     return e.getLength(); // We have a softclip area at the beginning

--- a/src/modes/ClusterMode.java
+++ b/src/modes/ClusterMode.java
@@ -21,7 +21,7 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import net.sf.samtools.SAMFileReader;
+import htsjdk.samtools.SAMFileReader;
 import setWeightCover.weightCoverEvents;
 import workers.BufferedSetReader;
 import workers.FlatFile;

--- a/src/modes/PreprocessMode.java
+++ b/src/modes/PreprocessMode.java
@@ -23,9 +23,10 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import net.sf.samtools.SAMFileHeader;
-import net.sf.samtools.SAMFileReader;
-import net.sf.samtools.SAMRecordIterator;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileReader;
+import htsjdk.samtools.SAMRecordIterator;
+import htsjdk.samtools.ValidationStringency;
 import workers.BamMetadataGeneration;
 import workers.MrsFastRuntimeFactory;
 
@@ -104,7 +105,7 @@ public class PreprocessMode {
         
         // Run through the BAM file generating split and divet data
         final SAMFileReader reader = new SAMFileReader(new File(input));
-        reader.setValidationStringency(SAMFileReader.ValidationStringency.SILENT);
+        reader.setValidationStringency(ValidationStringency.SILENT);
         
         SAMFileHeader h = reader.getFileHeader();
         List<BedSimple> coords = this.getSamIntervals(h);
@@ -114,7 +115,7 @@ public class PreprocessMode {
                 SamRecordMatcher w = new SamRecordMatcher(samplimit, checkRG, utilities.GetBaseName.getBaseName(outbase) + ".tmp", values, debug);
                 try{
                     SAMFileReader temp = new SAMFileReader(new File(input));
-                    temp.setValidationStringency(SAMFileReader.ValidationStringency.SILENT);
+                    temp.setValidationStringency(ValidationStringency.SILENT);
                     SAMRecordIterator itr = temp.queryContained(b.Chr(), b.Start(), b.End());
                     itr.forEachRemaining((k) -> w.bufferedAdd(k));
                     temp.close();
@@ -154,7 +155,7 @@ public class PreprocessMode {
         itr.close();*/
         
         SAMFileReader next = new SAMFileReader(new File(input));
-        next.setValidationStringency(SAMFileReader.ValidationStringency.SILENT);
+        next.setValidationStringency(ValidationStringency.SILENT);
         worker.convertToVariant(divets, splits);
         worker.RetrieveMissingAnchors(splits, next.iterator());
         

--- a/src/workers/BamMetadataGeneration.java
+++ b/src/workers/BamMetadataGeneration.java
@@ -18,12 +18,13 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import net.sf.samtools.BAMIndexer;
-import net.sf.samtools.SAMFileHeader;
-import net.sf.samtools.SAMFileReader;
-import net.sf.samtools.SAMReadGroupRecord;
-import net.sf.samtools.SAMRecord;
-import net.sf.samtools.SAMRecordIterator;
+import htsjdk.samtools.BAMIndexer;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileReader;
+import htsjdk.samtools.SAMReadGroupRecord;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMRecordIterator;
+import htsjdk.samtools.ValidationStringency;
 
 /**
  *
@@ -72,7 +73,7 @@ public class BamMetadataGeneration {
      */
     public void ScanFile(String input, int samplimit){
         SAMFileReader sam = new SAMFileReader(new File(input));
-        sam.setValidationStringency(SAMFileReader.ValidationStringency.SILENT);
+        sam.setValidationStringency(ValidationStringency.SILENT);
         if(!sam.hasIndex()){
             System.out.println("[METADATA] Could not find bam index file. Creating one now...");
             log.log(Level.INFO, "[METADATA] Generating bam index file for file: " + input);
@@ -86,7 +87,7 @@ public class BamMetadataGeneration {
             log.log(Level.FINE, "[METADATA] Finished generating bam index file.");
             sam = new SAMFileReader(new File(input));
         }
-        //sam.setValidationStringency(SAMFileReader.ValidationStringency.LENIENT);
+        //sam.setValidationStringency(ValidationStringency.LENIENT);
         header = sam.getFileHeader();
         if(expectRG){
             

--- a/src/workers/BufferedSetReader.java
+++ b/src/workers/BufferedSetReader.java
@@ -20,9 +20,10 @@ import java.util.HashMap;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import net.sf.samtools.SAMFileReader;
-import net.sf.samtools.SAMRecord;
-import net.sf.samtools.SAMRecordIterator;
+import htsjdk.samtools.SAMFileReader;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMRecordIterator;
+import htsjdk.samtools.ValidationStringency;
 import setWeightCover.BufferedInitialSet;
 import stats.GapOverlap;
 import stats.ReadNameUtility;
@@ -199,7 +200,7 @@ public class BufferedSetReader {
         HashMap<String, ArrayList<anchorRead>> anchors = new HashMap<>();
         //BufferedReader anchorReader = ReaderReturn.openFile(file.getAnchor().toFile());
         SAMFileReader sam = new SAMFileReader(file.getAnchor().toFile());
-        sam.setValidationStringency(SAMFileReader.ValidationStringency.SILENT);
+        sam.setValidationStringency(ValidationStringency.SILENT);
         //try{
             //String line;
             SAMRecordIterator itr = sam.iterator();
@@ -244,7 +245,7 @@ public class BufferedSetReader {
         this.hardUnbal = 0;
         
         try(SAMFileReader samReader = new SAMFileReader(file.getSplitsam().toFile())){
-            samReader.setValidationStringency(SAMFileReader.ValidationStringency.SILENT);
+            samReader.setValidationStringency(ValidationStringency.SILENT);
             SAMRecordIterator iterator = samReader.iterator();
             while(iterator.hasNext()){
                 SAMRecord line = iterator.next();

--- a/src/workers/MrsFastRuntimeFactory.java
+++ b/src/workers/MrsFastRuntimeFactory.java
@@ -21,13 +21,13 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import net.sf.samtools.DefaultSAMRecordFactory;
-import net.sf.samtools.SAMFileHeader;
-import net.sf.samtools.SAMFileWriter;
-import net.sf.samtools.SAMFileWriterFactory;
-import net.sf.samtools.SAMRecord;
-import net.sf.samtools.SAMRecordFactory;
-import net.sf.samtools.TextCigarCodec;
+import htsjdk.samtools.DefaultSAMRecordFactory;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMFileWriter;
+import htsjdk.samtools.SAMFileWriterFactory;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMRecordFactory;
+import htsjdk.samtools.TextCigarCodec;
 
 /**
  * This program runs MrsFAST and returns the output BAM file name
@@ -92,7 +92,6 @@ public class MrsFastRuntimeFactory{
             SAMRecordFactory recordCreator = new DefaultSAMRecordFactory();
             SAMFileWriterFactory sfact = new SAMFileWriterFactory();
             SAMFileWriter bam = sfact.makeBAMWriter(header, false, new File(outbase + "." + rg + ".bam"));
-            TextCigarCodec cd = TextCigarCodec.getSingleton();
             try(BufferedReader input = Files.newBufferedReader(Paths.get(samstr), Charset.defaultCharset())){
                 String line = null;
                 while((line = input.readLine()) != null){
@@ -110,7 +109,7 @@ public class MrsFastRuntimeFactory{
                     sam.setReferenceName(segs[2]);
                     sam.setAlignmentStart(Integer.valueOf(segs[3]));
                     sam.setMappingQuality(Integer.valueOf(segs[4]));
-                    sam.setCigar(cd.decode(segs[5]));
+                    sam.setCigar(TextCigarCodec.decode(segs[5]));
                     sam.setMateReferenceName(segs[6]);
                     sam.setMateAlignmentStart(Integer.valueOf(segs[7]));
                     sam.setInferredInsertSize(Integer.valueOf(segs[8]));

--- a/src/workers/TextFileQuickSort.java
+++ b/src/workers/TextFileQuickSort.java
@@ -87,7 +87,6 @@ public class TextFileQuickSort {
 	 * Reads the input io stream and splits it into sorted chunks which are written to temporary files. 
 	 * @param in
          * @param identifier
-	 * @throws IOException
 	 */
 	public void splitChunks(InputStream in, String identifier){
 		outputs.clear();
@@ -161,7 +160,6 @@ public class TextFileQuickSort {
 
 	/**
 	 * Reads the temporary files created by splitChunks method and merges them in a sorted manner into the output stream.
-	 * @param os
 	 * @throws IOException
 	 */
 	public void mergeChunks() throws IOException{


### PR DESCRIPTION
I thought it would be useful to be able to build RAPTR-SV from source and I thought that using htsjdk would be more up-to-date than net.sf.samtools

This adds those changes into the project and it can be built successfully with "ant" from the project root directory
